### PR TITLE
Add ability to include or exclude first element on sides

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ p.next     #=> #<Post>
 p.position #=> 5
 ```
 
+You can use `before` and `after` to build pagination. Both method accepts an additional boolean argument to decide if
+the relation should include the given point or not. By default they don't, if you want to include it use `before(true)`
+or `after(true)`.
+
 Looping to the first / last record is enabled for `next` / `previous` by default. Pass `false` to disable:
 
 ```ruby

--- a/lib/order_query/point.rb
+++ b/lib/order_query/point.rb
@@ -31,20 +31,23 @@ module OrderQuery
       space.count - after.count
     end
 
+    # @param [true, false] strict choose if the given scope should include or not the record, default not to include it (strict true)
     # @return [ActiveRecord::Relation]
-    def after
-      side :after
+    def after(strict = true)
+      side :after, strict
     end
 
+    # @param [true, false] strict choose if the given scope should include or not the record, default not to include it (strict true)
     # @return [ActiveRecord::Relation]
-    def before
-      side :before
+    def before(strict = true)
+      side :before, strict
     end
 
     # @param [:before, :after] side
+    # @param [true, false] strict choose if the given scope should include or not the record, default not to include it (strict true)
     # @return [ActiveRecord::Relation]
-    def side(side)
-      query, query_args = @where_sql.build(side)
+    def side(side, strict = true)
+      query, query_args = @where_sql.build(side, strict)
       scope = if side == :after
                 space.scope
               else

--- a/lib/order_query/sql/where.rb
+++ b/lib/order_query/sql/where.rb
@@ -19,10 +19,11 @@ module OrderQuery
       #     invoice < 3 OR
       #     invoices = 3 AND (
       #       ... ))
-      def build(side)
+      def build(side, strict = true)
         # generate pairs of terms such as sales < 5, sales = 5
-        terms = @columns.map { |col|
-          [where_side(col, side, true), where_tie(col)].reject { |x| x == WHERE_IDENTITY }
+        terms = @columns.map.with_index { |col, i|
+          be_strict = (i != @columns.size - 1) ? true : strict
+          [where_side(col, side, be_strict), where_tie(col)].reject { |x| x == WHERE_IDENTITY }
         }
         # group pairwise with OR, and nest with AND
         query = foldr_terms terms.map { |pair| join_terms 'OR'.freeze, *pair }, 'AND'.freeze


### PR DESCRIPTION
Allow the user to decide if the AR::Relation obtained from Point's
`after` and `before` (and `side`) should include the base element or not.

When building a pagination, this is the 'sane' way to obtain an active
record relation that doesn't miss any element.