### PR TITLE
Ability to specify custom value for ordered column

### DIFF
--- a/lib/order_query/column.rb
+++ b/lib/order_query/column.rb
@@ -4,7 +4,7 @@ require 'order_query/sql/column'
 module OrderQuery
   # An order column (sort column)
   class Column
-    attr_reader :name, :order_enum, :options
+    attr_reader :name, :order_enum, :value, :options
     delegate :column_name, :quote, to: :@sql
 
     # @option spec [String] :unique    Mark the attribute as unique to avoid redundant columns
@@ -22,6 +22,7 @@ module OrderQuery
           complete: true
       )
       @unique    = @options[:unique]
+      @value     = @options[:value]
       @sql       = SQL::Column.new(self, scope)
     end
 
@@ -61,6 +62,7 @@ module OrderQuery
           (@order_enum.inspect if order_enum),
           ('unique' if @unique),
           (column_name if options[:sql]),
+          (value if @value),
           @direction
       ].compact
       "(#{parts.join(' ')})"

--- a/lib/order_query/point.rb
+++ b/lib/order_query/point.rb
@@ -57,7 +57,7 @@ module OrderQuery
     end
 
     def value(cond)
-      record.send(cond.name)
+      cond.value || record.send(cond.name)
     end
 
     def inspect

--- a/spec/order_query_spec.rb
+++ b/spec/order_query_spec.rb
@@ -12,6 +12,10 @@ class Post < ActiveRecord::Base
               [:pinned, [true, false]],
               [:published_at, :desc],
               [:id, :desc]
+
+  def virtual_attr
+    Random.new.rand(100)
+  end
 end
 
 def create_post(attr = {})
@@ -308,6 +312,13 @@ describe 'OrderQuery' do
               expect(point.after(false).to_a).to eq [base, previous]
               expect(point.before(false).to_a).to eq [base, next_one]
             end
+          end
+        end
+
+        context 'order by custom value' do
+          it 'generates correct SQL' do
+            after_scope = create_post.seek([[:virtual_attr, :desc, sql: 'va', value: 100]]).after
+            expect(after_scope.to_sql).to include('va < 100 OR va = 100')
           end
         end
 


### PR DESCRIPTION
I have a case in that one record may have different values for a column.

What I have is a join of two tables. The first one is called `posts` and the second one is generated on the fly (using `unnest` PostgreSQL array function). I want to use keyset pagination and specify a column (it is called `priority`) from the second table. I can calculate the value of this column for a record for each query.
So in this case I want to pass this calculated value in `order_query` specification:
```
order_spec = [[:priority, :desc, sql: "second_table.priority", value: 3], ...]
post = Post.find(123)
OrderQuery::Space.new(Post.all, order_spec).at(post).after
```

This PR gives me an ability to pass this value.

I understand that my case is quite specific but maybe it will be useful for someone else