### PR TITLE
Make it compatible with Rails 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@
 
 source 'https://rubygems.org'
 
+# eval_gemfile 'spec/gemfiles/rails_6_1.gemfile'
 eval_gemfile 'spec/gemfiles/rails_6_0.gemfile'
 eval_gemfile 'rubocop.gemfile'

--- a/lib/order_query/nulls_direction.rb
+++ b/lib/order_query/nulls_direction.rb
@@ -32,7 +32,7 @@ module OrderQuery
     # @return [:first, :last] the default nulls order, based on the given
     #   scope's connection adapter name.
     def default(scope, dir)
-      case scope.connection_db_config[:adapter]
+      case scope.connection.adapter_name
       when /mysql|maria|sqlite|sqlserver/i
         (dir == :asc ? :first : :last)
       else

--- a/lib/order_query/nulls_direction.rb
+++ b/lib/order_query/nulls_direction.rb
@@ -32,7 +32,7 @@ module OrderQuery
     # @return [:first, :last] the default nulls order, based on the given
     #   scope's connection adapter name.
     def default(scope, dir)
-      case scope.connection_config[:adapter]
+      case scope.connection_db_config[:adapter]
       when /mysql|maria|sqlite|sqlserver/i
         (dir == :asc ? :first : :last)
       else

--- a/spec/gemfiles/rails_6_1.gemfile
+++ b/spec/gemfiles/rails_6_1.gemfile
@@ -4,8 +4,10 @@ source 'https://rubygems.org'
 
 gemspec path: '../../'
 
-gem 'activerecord', '~> 6.0.0'
-gem 'activesupport', '~> 6.0.0'
+git 'https://github.com/rails/rails.git' do
+  gem 'activerecord'
+  gem 'activesupport'
+end
 
 platforms :mri, :rbx do
   # https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13


### PR DESCRIPTION
Hi!

I made a couple of small changes to make the gem compatible with Rails 6.1alpha as well. This PR fixes the way the gem detects the database adapter name (the `connection_config` method has been removed in 6.1) so that it works with both Rails 6 and Rails 6.1alpha. For now since Rails 6.1 has not been released yet I've added the Gemfile but left the 6 enabled and I haven't changed the Travis config. I hope it's OK. Thanks!