### PR TITLE
Add support to ruby 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Ruby 3.0 now supported.
+
 ## 0.5.1
 
 * Rails 6.1 now supported.
@@ -23,7 +27,7 @@
 
 ## 0.3.4
 
-* The `before` and `after` methods now accept a boolean argument that indicates 
+* The `before` and `after` methods now accept a boolean argument that indicates
   whether the relation should exclude the given point or not.
   By default the given point is excluded, if you want to include it,
   use `before(false)` / `after(false)`.

--- a/lib/order_query/space.rb
+++ b/lib/order_query/space.rb
@@ -15,7 +15,7 @@ module OrderQuery
     def initialize(base_scope, order_spec)
       @base_scope = base_scope
       @columns = order_spec.map do |cond_spec|
-        Column.new(base_scope, *cond_spec)
+        build_column(base_scope, cond_spec)
       end
       # add primary key if columns are not unique
       unless @columns.last.unique?
@@ -57,6 +57,14 @@ module OrderQuery
     def inspect
       "#<OrderQuery::Space @columns=#{@columns.inspect} "\
       "@base_scope=#{@base_scope.inspect}>"
+    end
+
+    private
+
+    def build_column(base_scope, cond_spec)
+      column_spec = cond_spec.last.is_a?(Hash) ? cond_spec : cond_spec.push({})
+      attr_name, *vals_and_or_dir, options = column_spec
+      Column.new(base_scope, attr_name, *vals_and_or_dir, **options)
     end
   end
 end


### PR DESCRIPTION
There is a problem when using this gem with Ruby >3.0.
When initializing a column with `Column.new(base_scope, *cond_spec)`, the kwargs (`:nulls`, `:unique`, `:sql`) are assigned to `vals_and_or_dir` causing an `ArgumentError, extra arguments`.

@glebm , if you are interested, in my fork I adapted the CI to run in Github Actions, dropped EOL Ruby and Rails, added CI support to Rails 7 and Ruby 3. I didn't create a PR with these changes because it was very drastic changes and I didn't know if you wanted. Here's the changes: https://github.com/stephannv/order_query/pull/1.

