### PR TITLE
Do not mutate .seek order arguments

### DIFF
--- a/lib/order_query/space.rb
+++ b/lib/order_query/space.rb
@@ -14,7 +14,8 @@ module OrderQuery
     # @see Column#initialize for the order_spec element format.
     def initialize(base_scope, order_spec)
       @base_scope = base_scope
-      @columns = order_spec.map do |cond_spec|
+      @columns = order_spec.map(&:clone)
+      @columns.map! do |cond_spec|
         build_column(base_scope, cond_spec)
       end
       # add primary key if columns are not unique

--- a/spec/order_query_spec.rb
+++ b/spec/order_query_spec.rb
@@ -169,6 +169,12 @@ RSpec.describe 'OrderQuery' do
           )
         end
 
+        it '.seek does not mutate the given order arguments' do
+          order = [[:priority, :desc], [:id, :asc]]
+          Issue.seek(order)
+          expect(order).to eq [[:priority, :desc], [:id, :asc]]
+        end
+
         context 'partitioned on a boolean flag' do
           before do
             create_issue(active: true)


### PR DESCRIPTION
When passing an array of order arguments in the seek method, an extra hash is pushed into the same sub-arrays through the `OrderQuery::Space#build_column` method below. This behavior might be unexpected to some users, so as a fix, we clone the given order argument array's sub-array. 

example scenario:
```ruby   
order_args = [[:priority, :desc], [:id, :asc]]
space = Issue.seek(order_args)

order_args
=> [[:priority, :desc, {}], [:id, :asc, {}]]
```

**current OrderQuery::Space#build_column**
```ruby   
def build_column(base_scope, cond_spec)
      column_spec = cond_spec.last.is_a?(Hash) ? cond_spec : cond_spec.push({})
 ...
```
