### PR TITLE
Add support for Rails 8.0, bump to v0.5.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.5.5
+
+* Rails 8.0 now supported
+
 ## 0.5.4
 
 * Rails 7.2 now supported

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source 'https://rubygems.org'
 
-eval_gemfile 'spec/gemfiles/rails_7_2.gemfile'
+eval_gemfile 'spec/gemfiles/rails_8_0.gemfile'
 eval_gemfile 'rubocop.gemfile'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem finds the next or previous record(s) relative to the current one effici
 Add to Gemfile:
 
 ```ruby
-gem 'order_query', '~> 0.5.4'
+gem 'order_query', '~> 0.5.5'
 ```
 
 ## Usage

--- a/lib/order_query/version.rb
+++ b/lib/order_query/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OrderQuery
-  VERSION = '0.5.4'
+  VERSION = '0.5.5'
 end

--- a/order_query.gemspec
+++ b/order_query.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'activerecord', '>= 5.0', '< 7.3'
-  s.add_dependency 'activesupport', '>= 5.0', '< 7.3'
+  s.add_dependency 'activerecord', '>= 5.0', '< 8.1'
+  s.add_dependency 'activesupport', '>= 5.0', '< 8.1'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'simplecov'

--- a/spec/gemfiles/rails_8_0.gemfile
+++ b/spec/gemfiles/rails_8_0.gemfile
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../../'
+
+gem 'activerecord', '~> 8.0.0'
+gem 'activesupport', '~> 8.0.0'
+
+platforms :mri, :rbx do
+  gem 'sqlite3', '~> 2.2'
+  gem 'pg', '>= 0.18', '< 2.0'
+  gem 'mysql2', '>= 0.4.4'
+end
+
+group :test, :development do
+  gem 'ostruct'
+end
+
+eval_gemfile '../../shared.gemfile'


### PR DESCRIPTION
Hi,

With these changes, this gem can be used with Rails 8.0, is it possible to check and merge it?

I've ran the test suite locally for Sqlite and Postgresql and all tests pass.

I've also noticed the previous version (0.5.4) was never pushed to [Rubygems](https://rubygems.org/gems/order_query), maybe because there is a git tag missing, could you think about that as well, so we don't need to reference git repos in our Gemfile.

Thanks in advance!
